### PR TITLE
Add a bundle for all imports

### DIFF
--- a/all-imports.html
+++ b/all-imports.html
@@ -1,0 +1,9 @@
+<!--
+@license
+Copyright (c) 2017 Vaadin Ltd.
+This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+-->
+
+<link rel="import" href="vaadin-button.html">
+<link rel="import" href="vaadin-date-picker.html">
+<link rel="import" href="vaadin-text-field.html">


### PR DESCRIPTION
I'm proposing to provide the all-included option for developers. 

If this proposal will be approved for `material` theme I'll add documentation here and apply the same approach for the `valo` theme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-theme/8)
<!-- Reviewable:end -->
