### PR TITLE
Use new Material Design default palette colors

### DIFF
--- a/color.html
+++ b/color.html
@@ -9,17 +9,17 @@
       --material-disabled-text-color: var(--light-theme-disabled-color, rgba(0, 0, 0, 0.38));
 
       /* Primary colors */
-      --material-primary-color: var(--primary-color, #2962FF);
+      --material-primary-color: var(--primary-color, #6200ee);
       --material-primary-contrast-color: var(--dark-theme-base-color, #fff);
       --material-primary-text-color: var(--material-primary-color);
 
       /* Error colors */
-      --material-error-color: var(--error-color, #FF1744);
+      --material-error-color: var(--error-color, #b00020);
       --material-error-text-color: var(--material-error-color);
 
       /* Background colors */
       --material-background-color: var(--light-theme-background-color, #fff);
-      --material-secondary-background-color: var(--light-theme-secondary-background-color, #F5F5F5);
+      --material-secondary-background-color: var(--light-theme-secondary-background-color, #f5f5f5);
       --material-disabled-color: rgba(0, 0, 0, 0.26);
 
       /* Divider colors */
@@ -38,11 +38,11 @@
       --material-disabled-text-color: var(--dark-theme-disabled-color, rgba(255, 255, 255, 0.5));
 
       /* Primary colors */
-      --material-primary-color: var(--light-primary-color, #448AFF);
-      --material-primary-text-color: var(--material-primary-color);
+      --material-primary-color: var(--light-primary-color, #7e3ff2);
+      --material-primary-text-color: #9965f4;
 
       /* Error colors */
-      --material-error-color: var(--error-color, #FF5252);
+      --material-error-color: var(--error-color, #de2839);
       --material-error-text-color: var(--material-error-color);
 
       /* Background colors */
@@ -60,7 +60,7 @@
       /* Undocumented internal properties (prefixed with three dashes) */
 
       /* Text field tweaks */
-      --_material-text-field-input-line-background-color: #FFF;
+      --_material-text-field-input-line-background-color: #fff;
       --_material-text-field-input-line-opacity: 0.7;
       --_material-text-field-input-line-hover-opacity: 1;
       --_material-text-field-focused-label-opacity: 1;
@@ -77,9 +77,6 @@
 
       /* Split layout tweaks */
       --_material-split-layout-splitter-background-color: rgba(255, 255, 255, 0.8);
-
-      /* Progress bar tweaks */
-      --_material-success-color: rgb(37, 177, 95);
     }
   </style>
 </custom-style>
@@ -111,11 +108,11 @@
       --material-disabled-text-color: var(--dark-theme-disabled-color, rgba(255, 255, 255, 0.5));
 
       /* Primary colors */
-      --material-primary-color: var(--light-primary-color, #448AFF);
-      --material-primary-text-color: var(--material-primary-color);
+      --material-primary-color: var(--light-primary-color, #7e3ff2);
+      --material-primary-text-color: #9965f4;
 
       /* Error colors */
-      --material-error-color: var(--error-color, #FF5252);
+      --material-error-color: var(--error-color, #de2839);
       --material-error-text-color: var(--material-error-color);
 
       /* Background colors */
@@ -133,7 +130,7 @@
       /* Undocumented internal properties (prefixed with three dashes) */
 
       /* Text field tweaks */
-      --_material-text-field-input-line-background-color: #FFF;
+      --_material-text-field-input-line-background-color: #fff;
       --_material-text-field-input-line-opacity: 0.7;
       --_material-text-field-input-line-hover-opacity: 1;
       --_material-text-field-focused-label-opacity: 1;
@@ -147,6 +144,9 @@
 
       /* Grid tweaks */
       --_material-grid-row-hover-background-color: rgba(255, 255, 255, 0.08);
+
+      /* Split layout tweaks */
+      --_material-split-layout-splitter-background-color: rgba(255, 255, 255, 0.8);
     }
     </style>
   </template>


### PR DESCRIPTION
The dark palette colors are handpicked, as I didn’t find anything about those in the specs.

Converted hex values to lowercase at the same time.