### PR TITLE
Progress bar update

### DIFF
--- a/demo/progress-bars.html
+++ b/demo/progress-bars.html
@@ -54,16 +54,6 @@
       </template>
     </nice-demo-snippet>
 
-    <h3 demo-section>Colors</h3>
-    <nice-demo-snippet>
-      <template slot="source">
-        <h5>Error</h5>
-        <vaadin-progress-bar theme="error" value="0.7"></vaadin-progress-bar>
-        <h6>Indeterminate</h6>
-        <vaadin-progress-bar theme="error" indeterminate></vaadin-progress-bar>
-      </template>
-    </nice-demo-snippet>
-
     <script>
       document.addEventListener('WebComponentsReady', function() {
         const progress = document.querySelector('vaadin-progress-bar#dynamic');

--- a/vaadin-progress-bar.html
+++ b/vaadin-progress-bar.html
@@ -8,90 +8,80 @@
       :host {
         height: 4px;
         margin: 8px 0;
+        position: relative;
+        overflow: hidden;
+      }
+
+      :host::before {
+        content: "";
+        display: block;
+        height: 100%;
+        background-color: var(--material-primary-color);
+        opacity: 0.16;
       }
 
       [part="bar"] {
-        background-color: var(--material-divider-color);
+        position: absolute;
+        top: 0;
+        width: 100%;
+        transform: scaleX(var(--vaadin-progress-value));
+        transform-origin: 0 0;
       }
 
       [part="value"] {
-        background-color: var(--material-primary-color);
         transform: none;
-        width: calc(var(--vaadin-progress-value) * 100%);
-        min-width: 0.25em;
-        will-change: width;
-        transition: 0.2s width;
+        background-color: var(--material-primary-color);
       }
 
-      /* Indeterminate mode */
+      /* Indeterminate */
+
+      :host([indeterminate]) [part="bar"] {
+        left: -100%;
+        animation: primary-indeterminate-translate 2s infinite linear;
+      }
 
       :host([indeterminate]) [part="value"] {
-        --material-progress-indeterminate-progress-bar-background: var(--material-primary-color);
-        width: 30%;
-        background-color: var(--material-progress-indeterminate-progress-bar-background);
-        overflow: hidden;
-        will-change: transform;
-        animation: running-progress 4s linear infinite;
+        animation: primary-indeterminate-scale 2s infinite linear;
       }
 
-      @-webkit-keyframes running-progress {
+      @keyframes primary-indeterminate-translate {
         0% {
-          margin-left: 0;
-          margin-right: 100%;
-          width: 0%;
+          transform: translateX(0);
         }
 
-        37.5% {
-          margin-left: 0;
-          margin-right: 40%;
-          width: 60%;
+        20% {
+          animation-timing-function: cubic-bezier(.5, 0, .701732, .495819);
+          transform: translateX(0);
         }
 
-        62.5% {
-          margin-left: 40%;
-          margin-right: 0;
-          width: 60%;
+        59.15% {
+          animation-timing-function: cubic-bezier(.302435, .381352, .55, .956352);
+          transform: translateX(83.67142%);
         }
 
         100% {
-          margin-left: 100%;
-          margin-right: 0;
-          width: 0%;
+          transform: translateX(200.611057%);
         }
       }
 
-      @keyframes running-progress {
+      @keyframes primary-indeterminate-scale {
         0% {
-          margin-left: 0;
-          margin-right: 100%;
-          width: 0%;
+          transform: scaleX(.08);
         }
 
-        37.5% {
-          margin-left: 0;
-          margin-right: 40%;
-          width: 60%;
+        36.65% {
+          animation-timing-function: cubic-bezier(.334731, .12482, .785844, 1);
+          transform: scaleX(.08);
         }
 
-        62.5% {
-          margin-left: 40%;
-          margin-right: 0;
-          width: 60%;
+        69.15% {
+          animation-timing-function: cubic-bezier(.06, .11, .6, 1);
+          transform: scaleX(.661479);
         }
 
         100% {
-          margin-left: 100%;
-          margin-right: 0;
-          width: 0%;
+          transform: scaleX(.08);
         }
-      }
-
-      /* Error color */
-
-      :host([theme~="error"]) [part="value"],
-      :host([theme~="error"]) [part="value"]::before {
-        background-color: var(--material-error-color);
-        --material-progress-indeterminate-progress-bar-background: var(--material-error-color);
       }
 
     </style>


### PR DESCRIPTION
Indeterminate mode is still correct – it’s missing the secondary bar animation. Could try to use a pseudo-element for that.

Had to use a pseudo element for the track so that we can adjust the opacity. The new specs say it should be 6% opacity, but that seems incorrect when looking at the screenshots. The current 16% is chosen visually, which looks close enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-theme/38)
<!-- Reviewable:end -->
