### PR TITLE
Remove hack with pointer-events: none on [part=label]

### DIFF
--- a/demo/checkboxes.html
+++ b/demo/checkboxes.html
@@ -29,6 +29,12 @@
 
     <h1>Checkbox</h1>
 
+    <nice-demo-snippet>
+      <template slot="source">
+        <vaadin-checkbox checked>I agree with <a href="#">Terms & Conditions</a></vaadin-checkbox>
+      </template>
+    </nice-demo-snippet>
+
     <h3 demo-section>States</h3>
 
     <nice-demo-snippet>

--- a/vaadin-checkbox.html
+++ b/vaadin-checkbox.html
@@ -11,17 +11,6 @@
         -webkit-tap-highlight-color: transparent;
       }
 
-      /* This makes the :active style work in IE11 */
-      [part="label"] {
-        pointer-events: none;
-        transition: transform 0.3s;
-        will-change: transform;
-      }
-
-      [part="label"] > * {
-        pointer-events: auto;
-      }
-
       [part="label"]:not(:empty) {
         margin: 3px 12px 3px 6px;
       }

--- a/vaadin-radio-button.html
+++ b/vaadin-radio-button.html
@@ -12,17 +12,6 @@
         -webkit-tap-highlight-color: transparent;
       }
 
-      /* This makes the :active style work in IE11 */
-      [part="label"] {
-        pointer-events: none;
-        transition: transform 0.3s;
-        will-change: transform;
-      }
-
-      [part="label"] > * {
-        pointer-events: auto;
-      }
-
       [part="label"]:not(:empty) {
         margin: 4px 0.875em 4px 0.375em;
       }


### PR DESCRIPTION
Fixes #55 

@jouni this hack is useless. Active styles do not work in IE11 with and without it. Both for Lumo and Material. (I was trying with `:host(:active)` selector)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-theme/57)
<!-- Reviewable:end -->
